### PR TITLE
Fix resizeGrid for vertical grids with no/bad initial item positions

### DIFF
--- a/spec/findPositionForItemSpec.js
+++ b/spec/findPositionForItemSpec.js
@@ -65,6 +65,26 @@ describe("findPositionForItem", function() {
         expect(grid.findPositionForItem(item, {x: 0, y: 0}, 1)).toEqual([1, 1]);
       });
     });
+
+    describe("on an empty vertical grid", function() {
+      var grid;
+
+      beforeEach(function() {
+        grid = new GridList([], {lanes: 2, direction: 'vertical'});
+      });
+
+      it("should place it at the top", function() {
+        expect(grid.findPositionForItem(item, {x: 0, y: 0})).toEqual([0, 0]);
+      });
+
+      it("should place it ignoring the start position", function() {
+        expect(grid.findPositionForItem(item, {x: 1, y: 1})).toEqual([0, 0]);
+      });
+
+      it("should place it on the row I tell it to", function() {
+        expect(grid.findPositionForItem(item, {x: 0, y: 0}, 1)).toEqual([0, 1]);
+      });
+    });
   });
 
   describe("for an item that doesn't fit", function() {

--- a/spec/fixtures.js
+++ b/spec/fixtures.js
@@ -152,6 +152,17 @@ fixtures.verticalGridDemo = [
   {w: 1, h: 2, x: 2, y: 7}
 ];
 
+fixtures.VGRID1 = {
+  input: [
+    {w: 1, h: 1},
+    {w: 1, h: 1}
+  ],
+  target: [
+    {w: 1, h: 1, x: 0, y: 0},
+    {w: 1, h: 1, x: 1, y: 0}
+  ]
+};
+
 // Enable Node module
 if (typeof(require) == 'function') {
   for (var k in fixtures) {

--- a/spec/gridPositioningSpec.js
+++ b/spec/gridPositioningSpec.js
@@ -61,6 +61,21 @@ describe("Grid positioning", function() {
     });
   });
 
+  describe("vertical grid", function() {
+    describe("for grid configuration 1", function() {
+      var gridFixture = fixtures.VGRID1;
+      var grid = new GridList(GridList.cloneItems(gridFixture.input), {
+        lanes: 2,
+        direction: 'vertical'
+      });
+      grid.resizeGrid(2);
+
+      it("should lay out both items in the top row", function() {
+        expect(grid.items).toEqualPositions(gridFixture.target);
+      });
+    })
+  });
+
   it("should pull to left after resizing", function() {
     var grid = new GridList([
       {x: 0, y: 0, w: 1, h: 1},

--- a/src/gridList.js
+++ b/src/gridList.js
@@ -149,12 +149,13 @@ GridList.prototype = {
     // that is their "1d position"
     for (var i = 0; i < this.items.length; i++) {
       var item = this.items[i],
-          position = this._getItemPosition(item);
+          position;
 
       this._updateItemPosition(
         item, this.findPositionForItem(item, {x: currentColumn, y: 0}));
 
       // New items should never be placed to the left of previous items
+      position = this._getItemPosition(item);
       currentColumn = Math.max(currentColumn, position.x);
     }
 


### PR DESCRIPTION
Changes `resizeGrid` to fetch the current item's position after placing the item, instead of before. `findPositionForItem` returns the item in horizontal mode (so this works without issue), but a newly created object in vertical mode. This causes the layout algorithm to break if the items had no initial position, or if the initial position had to be disregarded.
