### PR TITLE
Remove grid margin when draggable deactivated

### DIFF
--- a/src/jquery.gridList.js
+++ b/src/jquery.gridList.js
@@ -263,10 +263,10 @@
       // right to allow dragging items to the end of the grid.
       if (this.options.direction === "horizontal") {
         this.$element.width(
-          (this.gridList.grid.length + this._widestItem) * this._cellWidth);
+          (this.gridList.grid.length + (this.options.dragAndDrop ? this._widestItem : 0)) * this._cellWidth);
       } else {
         this.$element.height(
-          (this.gridList.grid.length + this._tallestItem) * this._cellHeight);
+          (this.gridList.grid.length + (this.options.dragAndDrop ? this._tallestItem : 0)) * this._cellHeight);
       }
     },
 


### PR DESCRIPTION
Adding free space when draggable is not activated seems useless.
I added a condition to remove the margin when not needed.